### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Overview
+# Overview
 Very simply, this project demonstrates how to match an image to a bank of pre-existing images. It contains a simple front-end and image bank. The python implementation of the image bank can be easily adapted for other applications.
 
 The image comparisons use [SURF: Speeded Up Robust Features](http://www.vision.ee.ethz.ch/~surf/eccv06.pdf) which is **scale, orientation, and to some degree affine invariant**.
@@ -8,12 +8,12 @@ A common problem in managing large numbers of images is detecting *slight* dupli
 ![scale orientation invariant](http://i.imgur.com/nFASitk.gif)
 
 
-#Animated description
+# Animated description
 
 ![animation](http://i.cubeupload.com/8nVjdO.gif)
 
 
-#How it works
+# How it works
 To add an image to the bank:
 - Compute SURF descriptors for the image
 - Concatenate the descriptor to a "mega matrix" of pre-existing ones, making note of it's position.
@@ -28,8 +28,8 @@ To look up an image:
 The server is implemented using [flask](http://flask.pocoo.org/) and the front end uses [react](http://facebook.github.io/react/)
 
 
-#Install:
-##OSX
+# Install:
+## OSX
 Need to install `opencv` and `imagemagick` (todo: add links)
 ```sh
 pip install sqlite3
@@ -40,7 +40,7 @@ pip install flask
 npm install
 ```
 
-#Development:
+# Development:
 compile front end
 `webpack`
 
@@ -54,15 +54,15 @@ watch for changes on server:
 uncomment this line in `server.py` `app.debug = True`
 **note: this is by default on**
 
-#Optimization:
+# Optimization:
 - The implementation is poorly optimized, there is a rudimentary attempt to distribute the "mega matrix" to take advantage of multiple cores. At any sort of scale, you probably want to look into doing some sort of distributed nearest neighbor search.
 
 - By default the server persists the bank data in `bank.db` which is a simple sqlite database with pickled python objects. This is merely for convenience between server restarts. While it is running, the server keeps everything in local memory.
 
-#Related projects:
+# Related projects:
 - [isk-daemon](https://github.com/ricardocabral/iskdaemon)
 
-#Notes:
+# Notes:
 
 - Tested with around 200k images without issues.
 
@@ -71,7 +71,7 @@ uncomment this line in `server.py` `app.debug = True`
 - [A Sample dataset](http://www.vision.caltech.edu/Image_Datasets/Caltech256/). untar it and just POST them all to the server `find <MY_DATASET_DIR> -name "*.<IMAGE_EXTENSION>" -exec curl -i -F file=@{} \;`
 
 
-#LICENSE
+# LICENSE
 **mineye** source code is released under the **MIT License**
 
 The **SURF and SIFT algorithms implemented by OpenCV are patented** You will have to switch out the feature detector for something else.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
